### PR TITLE
Add coach tests with SWOLF and CSS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
   - Basic heuristics compute BMI, ape index, and suggest strokes/distances.
   - Included presets for Phelps, Dressel, Finke, Ledecky and McIntosh.
 - 2025-08-13: Introduced reusable swimmer shape for more realistic silhouette and mini-stroke panels.
+- 2025-08-13: Added simple coach tests panel with SWOLF and CSS calculations stored in localStorage.
 
 ## Instructions for future agents
 - Keep the project framework-free (vanilla JS, CSS, HTML).

--- a/index.html
+++ b/index.html
@@ -233,6 +233,22 @@
         </div>
         <small>Silhouettes and water flow update with your dimensions.</small>
       </div>
+      <div class="panel">
+        <h2>Coach Tests</h2>
+        <label>25m time (s) <input type="number" id="t25" step="0.01" /></label>
+        <label>25m strokes <input type="number" id="s25" step="1" /></label>
+        <button id="save25">Save 25m</button>
+        <div id="out25"></div>
+        <hr />
+        <label
+          >200m time (s) <input type="number" id="t200" step="0.01"
+        /></label>
+        <label
+          >400m time (s) <input type="number" id="t400" step="0.01"
+        /></label>
+        <button id="calcCSS">Calc CSS</button>
+        <div id="outCSS"></div>
+      </div>
       <div class="panel stats">
         <p>
           These suggestions do not limit you to any stroke or event—dedication

--- a/main.js
+++ b/main.js
@@ -91,6 +91,45 @@
     });
   }
 
+  const tests = JSON.parse(localStorage.getItem("tests") || "[]");
+
+  function save25() {
+    const time = parseFloat(document.getElementById("t25").value);
+    const strokes = parseFloat(document.getElementById("s25").value);
+    if (!time || !strokes) return;
+    const sw = swolf(time, strokes);
+    const d = dps(25, strokes);
+    const sr = strokeRate(strokes, time);
+    tests.push({
+      date: Date.now(),
+      time,
+      strokes,
+      swolf: sw,
+      dps: d,
+      sr,
+    });
+    localStorage.setItem("tests", JSON.stringify(tests));
+    document.getElementById("out25").textContent = `SWOLF ${sw.toFixed(
+      1,
+    )} | DPS ${d.toFixed(2)} m/st | SR ${sr.toFixed(1)} spm`;
+  }
+
+  function calcCSS() {
+    const t200 = parseFloat(document.getElementById("t200").value);
+    const t400 = parseFloat(document.getElementById("t400").value);
+    if (!t200 || !t400 || t400 <= t200) return;
+    const css = cssPace100(t200, t400);
+    const zones = zonesFromCSS(css);
+    document.getElementById("outCSS").textContent = `CSS ${css.toFixed(
+      2,
+    )} s/100 | Easy ${zones.easy.toFixed(1)} - Sprint ${zones.sprint.toFixed(
+      1,
+    )}`;
+  }
+
+  document.getElementById("save25").addEventListener("click", save25);
+  document.getElementById("calcCSS").addEventListener("click", calcCSS);
+
   // initialize with first preset
   presetSelect.value = "Michael Phelps";
   const init = presets[presetSelect.value];

--- a/metrics.js
+++ b/metrics.js
@@ -66,6 +66,38 @@ const presets = {
   },
 };
 
+function dps(distanceMeters, strokes) {
+  return strokes > 0 ? distanceMeters / strokes : 0;
+}
+
+function strokeRate(strokes, timeSeconds) {
+  return timeSeconds > 0 ? (strokes / timeSeconds) * 60 : 0;
+}
+
+function swolf(timeSeconds, strokes) {
+  return (timeSeconds || 0) + (strokes || 0);
+}
+
+function cssPace100(t200Seconds, t400Seconds) {
+  if (!t200Seconds || !t400Seconds || t400Seconds <= t200Seconds) return 0;
+  return (t400Seconds - t200Seconds) / 2;
+}
+
+function zonesFromCSS(css100) {
+  return {
+    easy: css100 + 8,
+    steady: css100 + 4,
+    css: css100,
+    speed: css100 - 4,
+    sprint: css100 - 8,
+  };
+}
+
+function worldAquaticsPoints(timeSeconds, baseTimeSeconds) {
+  if (!timeSeconds || !baseTimeSeconds) return 0;
+  return Math.floor(1000 * (baseTimeSeconds / timeSeconds) ** 3);
+}
+
 function computeMetrics(data) {
   const h = data.height;
   const w = data.weight;
@@ -116,5 +148,14 @@ function computeMetrics(data) {
 }
 
 if (typeof module !== "undefined") {
-  module.exports = { computeMetrics, presets };
+  module.exports = {
+    computeMetrics,
+    presets,
+    dps,
+    strokeRate,
+    swolf,
+    cssPace100,
+    zonesFromCSS,
+    worldAquaticsPoints,
+  };
 }


### PR DESCRIPTION
## Summary
- add coach tests panel for 25m and CSS calculations
- provide SWOLF, DPS, stroke rate utilities and world aquatics points stub
- store test data in localStorage and show pace zones

## Testing
- `npx prettier --check index.html main.js metrics.js`


------
https://chatgpt.com/codex/tasks/task_e_689ceb57889c8327a4dc16016fb2753f