### PR TITLE
Use stick figure swimmer and color-coded stroke panels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
   - Included presets for Phelps, Dressel, Finke, Ledecky and McIntosh.
 - 2025-08-13: Introduced reusable swimmer shape for more realistic silhouette and mini-stroke panels.
 - 2025-08-13: Added simple coach tests panel with SWOLF and CSS calculations stored in localStorage.
+- 2025-08-26: Replaced swimmer silhouette with adjustable stick figure and added animated mini-stroke panels colored by stroke suitability.
 
 ## Instructions for future agents
 - Keep the project framework-free (vanilla JS, CSS, HTML).

--- a/index.html
+++ b/index.html
@@ -49,12 +49,15 @@
       svg#silhouette path,
       svg#silhouette rect,
       svg#silhouette circle,
+      svg#silhouette line,
       .miniStroke svg path,
       .miniStroke svg rect,
-      .miniStroke svg circle {
+      .miniStroke svg circle,
+      .miniStroke svg line {
         fill: #d4d4d8;
         stroke: #4b5563;
         stroke-width: 2;
+        stroke-linecap: round;
       }
       .stats {
         font-size: 0.9rem;
@@ -75,6 +78,16 @@
         background: #f1f5f9;
         border-radius: 6px;
         overflow: hidden;
+        border: 2px solid #9ca3af;
+      }
+      .miniStroke.good {
+        border-color: #fb923c;
+      }
+      .miniStroke.ok {
+        border-color: #93c5fd;
+      }
+      .miniStroke.poor {
+        border-color: #9ca3af;
       }
       .miniStroke::after {
         content: attr(data-label);
@@ -97,20 +110,7 @@
     <svg
       xmlns="http://www.w3.org/2000/svg"
       style="position: absolute; width: 0; height: 0"
-    >
-      <defs>
-        <g id="swimmerShape">
-          <circle cx="100" cy="20" r="10"></circle>
-          <path
-            d="M95 30 L105 30 C110 50 110 70 105 90 L95 90 C90 70 90 50 95 30Z"
-          ></path>
-          <path d="M95 40 L15 50 L15 60 L95 50Z"></path>
-          <path d="M105 40 L185 50 L185 60 L105 50Z"></path>
-          <path d="M95 90 L90 160 L96 160 L100 90Z"></path>
-          <path d="M105 90 L110 160 L104 160 L100 90Z"></path>
-        </g>
-      </defs>
-    </svg>
+    ></svg>
     <h1>SwimMatch Prototype</h1>
     <div class="dashboard">
       <div class="panel">
@@ -156,7 +156,7 @@
       </div>
       <div class="panel" id="silhouette-container">
         <svg id="silhouette" viewBox="0 0 200 200">
-          <g id="person"><use href="#swimmerShape"></use></g>
+          <g id="person"></g>
         </svg>
       </div>
       <div class="panel stats">
@@ -185,7 +185,7 @@
                   repeatCount="indefinite"
                 />
               </rect>
-              <g class="miniPerson"><use href="#swimmerShape"></use></g>
+              <g class="miniPerson"></g>
             </svg>
           </div>
           <div class="miniStroke" data-label="Backstroke">
@@ -199,7 +199,7 @@
                   repeatCount="indefinite"
                 />
               </rect>
-              <g class="miniPerson"><use href="#swimmerShape"></use></g>
+              <g class="miniPerson"></g>
             </svg>
           </div>
           <div class="miniStroke" data-label="Breaststroke">
@@ -213,7 +213,7 @@
                   repeatCount="indefinite"
                 />
               </rect>
-              <g class="miniPerson"><use href="#swimmerShape"></use></g>
+              <g class="miniPerson"></g>
             </svg>
           </div>
           <div class="miniStroke" data-label="Butterfly">
@@ -227,7 +227,7 @@
                   repeatCount="indefinite"
                 />
               </rect>
-              <g class="miniPerson"><use href="#swimmerShape"></use></g>
+              <g class="miniPerson"></g>
             </svg>
           </div>
         </div>

--- a/main.js
+++ b/main.js
@@ -66,28 +66,120 @@
       .map((s) => s[0])
       .join(", ");
     drawSilhouette(data);
-    drawMini(data);
+    drawMini(data, m);
+  }
+
+  const NS = "http://www.w3.org/2000/svg";
+
+  function buildStick(data, scale) {
+    const g = document.createElementNS(NS, "g");
+    const line = (x1, y1, x2, y2) => {
+      const l = document.createElementNS(NS, "line");
+      l.setAttribute("x1", x1);
+      l.setAttribute("y1", y1);
+      l.setAttribute("x2", x2);
+      l.setAttribute("y2", y2);
+      return l;
+    };
+    const torso = (data.torso || 70) * scale;
+    const leg = (data.leg || 90) * scale;
+    const shoulder = (data.shoulder || 40) * scale;
+    const arm =
+      (((data.wingspan || data.height || 180) - shoulder) / 2) * scale;
+    const headR = 10 * scale;
+    const neckY = headR * 2;
+    const armY = neckY + headR * 0.2;
+    const hipY = neckY + torso;
+    const footY = hipY + leg;
+
+    const parts = { g };
+    const head = document.createElementNS(NS, "circle");
+    head.setAttribute("cx", 0);
+    head.setAttribute("cy", headR);
+    head.setAttribute("r", headR);
+    g.appendChild(head);
+    parts.head = head;
+
+    const body = line(0, neckY, 0, hipY);
+    g.appendChild(body);
+    parts.body = body;
+
+    const leftArm = line(0, armY, -arm, armY + 10 * scale);
+    const rightArm = line(0, armY, arm, armY + 10 * scale);
+    g.appendChild(leftArm);
+    g.appendChild(rightArm);
+    parts.leftArm = leftArm;
+    parts.rightArm = rightArm;
+
+    const leftLeg = line(0, hipY, -shoulder / 4, footY);
+    const rightLeg = line(0, hipY, shoulder / 4, footY);
+    g.appendChild(leftLeg);
+    g.appendChild(rightLeg);
+    parts.leftLeg = leftLeg;
+    parts.rightLeg = rightLeg;
+
+    return parts;
   }
 
   function drawSilhouette(data) {
     const person = document.getElementById("person");
-    const hScale = (data.height || 180) / 180;
-    const wScale = (data.wingspan || data.height || 180) / 200; // base wingspan 200
-    person.setAttribute(
-      "transform",
-      `translate(100,0) scale(${wScale},${hScale}) translate(-100,0)`,
-    );
+    person.innerHTML = "";
+    const scale = 160 / ((data.torso || 70) + (data.leg || 90) + 40);
+    const stick = buildStick(data, scale);
+    stick.g.setAttribute("transform", "translate(100,10)");
+    person.appendChild(stick.g);
   }
 
-  function drawMini(data) {
-    document.querySelectorAll(".miniPerson").forEach((p) => {
-      const hScale = (data.height || 180) / 180;
-      const wScale = (data.wingspan || data.height || 180) / 200;
-      const base = 0.3;
-      p.setAttribute(
-        "transform",
-        `translate(50,5) scale(${base * wScale},${base * hScale}) translate(-100,0)`,
-      );
+  function addRotate(el, from, to, dur, begin) {
+    const anim = document.createElementNS(NS, "animateTransform");
+    anim.setAttribute("attributeName", "transform");
+    anim.setAttribute("type", "rotate");
+    anim.setAttribute(
+      "from",
+      `${from} ${el.getAttribute("x1")} ${el.getAttribute("y1")}`,
+    );
+    anim.setAttribute(
+      "to",
+      `${to} ${el.getAttribute("x1")} ${el.getAttribute("y1")}`,
+    );
+    anim.setAttribute("dur", dur);
+    anim.setAttribute("repeatCount", "indefinite");
+    if (begin) anim.setAttribute("begin", begin);
+    el.appendChild(anim);
+  }
+
+  function drawMini(data, metrics) {
+    document.querySelectorAll(".miniStroke").forEach((panel) => {
+      const name = panel.dataset.label;
+      const container = panel.querySelector(".miniPerson");
+      container.innerHTML = "";
+      const score = metrics.strokes[name] || 0;
+      panel.classList.remove("good", "ok", "poor");
+      if (score >= 3) panel.classList.add("good");
+      else if (score > 0) panel.classList.add("ok");
+      else panel.classList.add("poor");
+
+      const scale = 30 / ((data.torso || 70) + (data.leg || 90));
+      const stick = buildStick(data, scale);
+      stick.g.setAttribute("transform", "translate(20,30) rotate(90)");
+      container.appendChild(stick.g);
+
+      if (name === "Freestyle" || name === "Backstroke") {
+        addRotate(stick.leftArm, 0, 360, "2s");
+        addRotate(stick.rightArm, 180, 540, "2s");
+        addRotate(stick.leftLeg, -30, 30, "0.6s");
+        addRotate(stick.rightLeg, 30, -30, "0.6s");
+      } else if (name === "Breaststroke") {
+        addRotate(stick.leftArm, -30, 30, "1.2s");
+        addRotate(stick.rightArm, 30, -30, "1.2s");
+        addRotate(stick.leftLeg, -20, 20, "1.2s");
+        addRotate(stick.rightLeg, 20, -20, "1.2s");
+      } else if (name === "Butterfly") {
+        addRotate(stick.leftArm, -60, 60, "1s");
+        addRotate(stick.rightArm, -60, 60, "1s", "0s");
+        addRotate(stick.leftLeg, -20, 20, "0.8s");
+        addRotate(stick.rightLeg, -20, 20, "0.8s");
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- replace silhouette with dynamically scaled stick figure
- animate mini stroke figures in streamline and color panels by stroke metric

## Testing
- `npx prettier --check index.html main.js metrics.js`


------
https://chatgpt.com/codex/tasks/task_e_689d1064ad908327bdec18330de00dba